### PR TITLE
Remove application/json from supported mediaTypes of hal converter

### DIFF
--- a/activiti-cloud-services-dbp-rest/pom.xml
+++ b/activiti-cloud-services-dbp-rest/pom.xml
@@ -19,6 +19,10 @@
       <artifactId>spring-boot-starter-data-rest</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springframework.data</groupId>
+      <artifactId>spring-data-rest-webmvc</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
     </dependency>

--- a/activiti-cloud-services-dbp-rest/src/main/java/org/activiti/cloud/alfresco/config/AlfrescoWebConfigurer.java
+++ b/activiti-cloud-services-dbp-rest/src/main/java/org/activiti/cloud/alfresco/config/AlfrescoWebConfigurer.java
@@ -16,11 +16,15 @@
 
 package org.activiti.cloud.alfresco.config;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.activiti.cloud.alfresco.argument.resolver.AlfrescoPageArgumentMethodResolver;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
+import org.springframework.hateoas.mvc.TypeConstrainedMappingJackson2HttpMessageConverter;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -37,5 +41,19 @@ public class AlfrescoWebConfigurer implements WebMvcConfigurer {
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(0, alfrescoPageArgumentMethodResolver);
+    }
+
+    @Override
+    public void extendMessageConverters(List<HttpMessageConverter<?>> converters) {
+        //the property spring.hateoas.use-hal-as-default-json-media-type is not working
+        //we need to manually remove application/json from supported mediaTypes
+        for (HttpMessageConverter<?> converter : converters) {
+            if (converter instanceof TypeConstrainedMappingJackson2HttpMessageConverter ) {
+                ArrayList<MediaType> mediaTypes = new ArrayList<>(converter.getSupportedMediaTypes());
+                mediaTypes.remove(MediaType.APPLICATION_JSON);
+                ((TypeConstrainedMappingJackson2HttpMessageConverter) converter).setSupportedMediaTypes(mediaTypes);
+            }
+        }
+
     }
 }

--- a/activiti-cloud-services-dbp-rest/src/main/resources/config/alfresco-rest-config.properties
+++ b/activiti-cloud-services-dbp-rest/src/main/resources/config/alfresco-rest-config.properties
@@ -1,2 +1,1 @@
-spring.hateoas.use-hal-as-default-json-media-type=false
 spring.data.rest.default-page-size=100

--- a/activiti-cloud-services-dbp-rest/src/test/java/org/activiti/cloud/alfresco/config/AlfrescoWebConfigurerTest.java
+++ b/activiti-cloud-services-dbp-rest/src/test/java/org/activiti/cloud/alfresco/config/AlfrescoWebConfigurerTest.java
@@ -17,6 +17,8 @@
 package org.activiti.cloud.alfresco.config;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import org.activiti.cloud.alfresco.argument.resolver.AlfrescoPageArgumentMethodResolver;
@@ -24,6 +26,10 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.springframework.hateoas.MediaTypes;
+import org.springframework.hateoas.Resource;
+import org.springframework.hateoas.mvc.TypeConstrainedMappingJackson2HttpMessageConverter;
+import org.springframework.http.MediaType;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -56,4 +62,17 @@ public class AlfrescoWebConfigurerTest {
         assertThat(resolvers.get(0)).isEqualTo(alfrescoPageArgumentMethodResolver);
     }
 
+    @Test
+    public void extendMessageConvertersShouldRemoveApplicationJsonFromHalConverter() throws Exception {
+        //given
+
+        //when
+        TypeConstrainedMappingJackson2HttpMessageConverter halConverter = new TypeConstrainedMappingJackson2HttpMessageConverter(Resource.class);
+        halConverter.setSupportedMediaTypes(Arrays.asList(MediaTypes.HAL_JSON,
+                                                          MediaType.APPLICATION_JSON));
+        configurer.extendMessageConverters(Collections.singletonList(halConverter));
+
+        //then
+        assertThat(halConverter.getSupportedMediaTypes()).containsExactly(MediaTypes.HAL_JSON);
+    }
 }


### PR DESCRIPTION
It was previously using the property spring.hateoas.use-hal-as-default-json-media-type, but it seems to be no longer working