### PR TITLE
1891 fix empty collection in hal reponse

### DIFF
--- a/activiti-cloud-services-dbp-rest/pom.xml
+++ b/activiti-cloud-services-dbp-rest/pom.xml
@@ -28,6 +28,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/activiti-cloud-services-dbp-rest/src/main/java/org/activiti/cloud/alfresco/converter/json/PagedResourcesConverter.java
+++ b/activiti-cloud-services-dbp-rest/src/main/java/org/activiti/cloud/alfresco/converter/json/PagedResourcesConverter.java
@@ -37,11 +37,13 @@ public class PagedResourcesConverter {
     }
 
     public <T> AlfrescoPageContentListWrapper<T> toAlfrescoContentListWrapper(PagedResources<Resource<T>> pagedResources) {
-        Collection<Resource<T>> pagedResourceContent = pagedResources.getContent();
-        List<AlfrescoContentEntry<T>> baseContent = pagedResourceContent.stream()
-                .map(
-                        resource -> new AlfrescoContentEntry<>(resource.getContent())
-                ).collect(Collectors.toList());
+        Collection<?> pagedResourceContent = pagedResources.getContent();
+        List<AlfrescoContentEntry<T>> baseContent = pagedResourceContent
+                .stream()
+                .filter(resource -> resource instanceof Resource)
+                .map(resource -> ((Resource<T>) resource).getContent())
+                .map(AlfrescoContentEntry::new)
+                .collect(Collectors.toList());
 
         AlfrescoPageMetadata pagination = pageMetadataConverter.toAlfrescoPageMetadata(pagedResources.getMetadata(),
                                                                                        baseContent.size());

--- a/activiti-cloud-services-dbp-rest/src/main/java/org/activiti/cloud/alfresco/data/domain/AlfrescoPagedResourcesAssembler.java
+++ b/activiti-cloud-services-dbp-rest/src/main/java/org/activiti/cloud/alfresco/data/domain/AlfrescoPagedResourcesAssembler.java
@@ -50,15 +50,19 @@ public class AlfrescoPagedResourcesAssembler<T> extends PagedResourcesAssembler<
 
     public <R extends ResourceSupport> PagedResources<R> toResource(Pageable pageable,
                                                                     Page<T> page,
+                                                                    Class<T> entityType,
                                                                     ResourceAssembler<T, R> assembler) {
-        PagedResources<R> pagedResources = toResource(page,
-                                                            assembler);
-        ExtendedPageMetadata extendedPageMetadata = extendedPageMetadataConverter.toExtendedPageMetadata(pageable.getOffset(),
-                                                                                                         pagedResources.getMetadata());
-        pagedResources = new PagedResources<>(pagedResources.getContent(),
-                                              extendedPageMetadata,
-                                              pagedResources.getLinks());
+        PagedResources<R> pagedResources = page.getContent().isEmpty() ?
+                (PagedResources<R>) toEmptyResource(page,
+                                                    entityType) :
+                toResource(page,
+                           assembler);
 
-        return pagedResources;
+        ExtendedPageMetadata extendedPageMetadata = extendedPageMetadataConverter
+                .toExtendedPageMetadata(pageable.getOffset(),
+                                        pagedResources.getMetadata());
+        return new PagedResources<>(pagedResources.getContent(),
+                                    extendedPageMetadata,
+                                    pagedResources.getLinks());
     }
 }

--- a/activiti-cloud-services-dbp-rest/src/test/java/org/activiti/cloud/alfresco/config/AlfrescoApplicationIT.java
+++ b/activiti-cloud-services-dbp-rest/src/test/java/org/activiti/cloud/alfresco/config/AlfrescoApplicationIT.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.cloud.alfresco.config;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class AlfrescoApplicationIT {
+
+    public static void main(String[] args) {
+        SpringApplication.run(AlfrescoApplicationIT.class,
+                              args);
+    }
+}

--- a/activiti-cloud-services-dbp-rest/src/test/java/org/activiti/cloud/alfresco/data/domain/AlfrescoPagedResourcesAssemblerIT.java
+++ b/activiti-cloud-services-dbp-rest/src/test/java/org/activiti/cloud/alfresco/data/domain/AlfrescoPagedResourcesAssemblerIT.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.cloud.alfresco.data.domain;
+
+import org.activiti.cloud.alfresco.config.AlfrescoApplicationIT;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.data.web.config.EnableSpringDataWebSupport;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.hateoas.MediaTypes.HAL_JSON_VALUE;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = AlfrescoApplicationIT.class)
+@EnableSpringDataWebSupport
+@AutoConfigureMockMvc
+@ComponentScan(basePackages = {"org.activiti.cloud.alfresco"})
+public class AlfrescoPagedResourcesAssemblerIT {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+    public void testGetHalEmptyPage() throws Exception {
+        mockMvc
+                //when
+                .perform(get("/mock/empty-list").accept(HAL_JSON_VALUE))
+                //then
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded.strings",
+                                    hasSize(0)));
+    }
+
+    @Test
+    @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+    public void testGetAlfrescoEmptyPage() throws Exception {
+        mockMvc
+                //when
+                .perform(get("/mock/empty-list").accept(APPLICATION_JSON_VALUE))
+                //then
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.list.entries",
+                                    hasSize(0)));
+    }
+
+    @Test
+    @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+    public void testGetHalSingletonPage() throws Exception {
+        mockMvc
+                //when
+                .perform(get("/mock/singleton-list").accept(HAL_JSON_VALUE))
+                //then
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded.strings",
+                                    hasSize(1)));
+    }
+
+    @Test
+    @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
+    public void testGetAlfrescoSingletonPage() throws Exception {
+        mockMvc
+                //when
+                .perform(get("/mock/singleton-list").accept(APPLICATION_JSON_VALUE))
+                //then
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.list.entries",
+                                    hasSize(1)));
+    }
+}

--- a/activiti-cloud-services-dbp-rest/src/test/java/org/activiti/cloud/alfresco/data/domain/AlfrescoPagedResourcesAssemblerTest.java
+++ b/activiti-cloud-services-dbp-rest/src/test/java/org/activiti/cloud/alfresco/data/domain/AlfrescoPagedResourcesAssemblerTest.java
@@ -16,8 +16,6 @@
 
 package org.activiti.cloud.alfresco.data.domain;
 
-import java.util.Collections;
-
 import org.activiti.cloud.alfresco.argument.resolver.AlfrescoPageRequest;
 import org.junit.Before;
 import org.junit.Test;
@@ -25,11 +23,13 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.springframework.data.domain.Page;
+import org.springframework.data.repository.support.PageableExecutionUtils;
 import org.springframework.hateoas.Link;
 import org.springframework.hateoas.PagedResources;
 import org.springframework.hateoas.ResourceAssembler;
 import org.springframework.hateoas.ResourceSupport;
 
+import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doReturn;
@@ -48,9 +48,6 @@ public class AlfrescoPagedResourcesAssemblerTest {
     @Mock
     private ResourceAssembler<String, ResourceSupport> resourceAssembler;
 
-    @Mock
-    private Page<String> page;
-
     @Before
     public void setUp() throws Exception {
         initMocks(this);
@@ -64,22 +61,29 @@ public class AlfrescoPagedResourcesAssemblerTest {
                                                                           null);
 
         PagedResources.PageMetadata baseMetadata = new PagedResources.PageMetadata(10,
-                                                                               0,
-                                                                               30);
+                                                                                   0,
+                                                                                   30);
         ResourceSupport resourceSupport = new ResourceSupport();
         Link link = mock(Link.class);
-        PagedResources<ResourceSupport> basePagedResources = new PagedResources<>(Collections.singletonList(resourceSupport),
-                                                                                        baseMetadata,
-                                                                                        link);
+        PagedResources<ResourceSupport> basePagedResources = new PagedResources<>(singletonList(resourceSupport),
+                                                                                  baseMetadata,
+                                                                                  link);
+
+        Page<String> page = PageableExecutionUtils
+                .getPage(singletonList("any"),
+                         alfrescoPageRequest,
+                         () -> 100);
 
         doReturn(basePagedResources).when(alfrescoPagedResourcesAssembler).toResource(page,
                                                                                       resourceAssembler);
         ExtendedPageMetadata extendedPageMetadata = mock(ExtendedPageMetadata.class);
-        given(extendedPageMetadataConverter.toExtendedPageMetadata(alfrescoPageRequest.getOffset(), baseMetadata)).willReturn(extendedPageMetadata);
+        given(extendedPageMetadataConverter.toExtendedPageMetadata(alfrescoPageRequest.getOffset(),
+                                                                   baseMetadata)).willReturn(extendedPageMetadata);
 
         //when
         PagedResources<ResourceSupport> pagedResources = alfrescoPagedResourcesAssembler.toResource(alfrescoPageRequest,
                                                                                                     page,
+                                                                                                    String.class,
                                                                                                     resourceAssembler);
 
         //then
@@ -88,5 +92,4 @@ public class AlfrescoPagedResourcesAssemblerTest {
         assertThat(pagedResources.getContent()).containsExactly(resourceSupport);
         assertThat(pagedResources.getLinks()).contains(link);
     }
-
 }

--- a/activiti-cloud-services-dbp-rest/src/test/java/org/activiti/cloud/alfresco/mock/MockRestController.java
+++ b/activiti-cloud-services-dbp-rest/src/test/java/org/activiti/cloud/alfresco/mock/MockRestController.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.cloud.alfresco.mock;
+
+import java.util.List;
+
+import org.activiti.cloud.alfresco.data.domain.AlfrescoPagedResourcesAssembler;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.repository.support.PageableExecutionUtils;
+import org.springframework.hateoas.PagedResources;
+import org.springframework.hateoas.Resource;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.springframework.hateoas.MediaTypes.HAL_JSON_VALUE;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static org.springframework.web.bind.annotation.RequestMethod.GET;
+
+/**
+ * Mock rest controller
+ */
+@RestController
+@RequestMapping(
+        value = "/mock",
+        produces = {
+                HAL_JSON_VALUE,
+                APPLICATION_JSON_VALUE
+        }
+)
+public class MockRestController {
+
+    @Autowired
+    private AlfrescoPagedResourcesAssembler<String> pagedResourcesAssembler;
+
+    @Autowired
+    private MockRestResourceAssembler resourceAssembler;
+
+    @RequestMapping(method = GET, path = "/empty-list")
+    public PagedResources<Resource<String>> getEmptyPage(Pageable pageable) {
+        return pagedResourcesAssembler.toResource(pageable,
+                                                  createPage(emptyList(),
+                                                             pageable),
+                                                  String.class,
+                                                  resourceAssembler);
+    }
+
+    @RequestMapping(method = GET, path = "/singleton-list")
+    public PagedResources<Resource<String>> getSingletonPage(Pageable pageable) {
+        return pagedResourcesAssembler.toResource(pageable,
+                                                  createPage(singletonList("any"),
+                                                             pageable),
+                                                  String.class,
+                                                  resourceAssembler);
+    }
+
+    private Page<String> createPage(List<String> content,
+                                    Pageable pageable) {
+        return PageableExecutionUtils
+                .getPage(content,
+                         pageable,
+                         () -> 100);
+    }
+}

--- a/activiti-cloud-services-dbp-rest/src/test/java/org/activiti/cloud/alfresco/mock/MockRestResourceAssembler.java
+++ b/activiti-cloud-services-dbp-rest/src/test/java/org/activiti/cloud/alfresco/mock/MockRestResourceAssembler.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.cloud.alfresco.mock;
+
+import org.springframework.hateoas.Resource;
+import org.springframework.hateoas.ResourceAssembler;
+import org.springframework.stereotype.Component;
+
+/**
+ * Mock REST resource assembler
+ */
+@Component
+public class MockRestResourceAssembler implements ResourceAssembler<String, Resource<String>> {
+
+    @Override
+    public Resource<String> toResource(String entity) {
+        return new Resource<>(entity);
+    }
+}


### PR DESCRIPTION
- use empty resource EmptyCollectionEmbeddedWrapper in case of empty collection content
- update PagedResourcesConverter for the case of EmptyCollectionEmbeddedWrapper in content
- add integration tests for empty and not empty collections in both hal and alfresco requests

https://github.com/Activiti/Activiti/issues/1891