### PR TITLE
Modify task builder for tests

### DIFF
--- a/activiti-cloud-services-test/src/main/java/org/activiti/cloud/starters/test/builder/TaskEventContainedBuilder.java
+++ b/activiti-cloud-services-test/src/main/java/org/activiti/cloud/starters/test/builder/TaskEventContainedBuilder.java
@@ -102,7 +102,7 @@ public class TaskEventContainedBuilder {
                               processInstance);
         eventsAggregator.addEvents(new CloudTaskCreatedEventImpl(task),
                                    new CloudTaskAssignedEventImpl(task),
-                                   new CloudTaskCompletedEventImpl(task));
+                                   new CloudTaskCompletedEventImpl(UUID.randomUUID().toString(), new Date().getTime(), task));
         return task;
     }
 
@@ -152,6 +152,7 @@ public class TaskEventContainedBuilder {
         TaskImpl task = new TaskImpl(UUID.randomUUID().toString(),
                                      taskName,
                                      status);
+        task.setCreatedDate(new Date());
         if(processInstance != null) {
             task.setProcessInstanceId(processInstance.getId());
         }


### PR DESCRIPTION
This PR sets the now required completion and creation dates of tasks in order for Duration to be calculated in the TaskCompletedHandlerEvent in Query Service, as stated in this issue: https://github.com/Activiti/Activiti/issues/2281