### PR TITLE
Fix swagger specification file for alfresco format

### DIFF
--- a/activiti-cloud-service-common-dependencies/pom.xml
+++ b/activiti-cloud-service-common-dependencies/pom.xml
@@ -117,6 +117,11 @@
         <artifactId>activiti-cloud-services-rest-docs</artifactId>
         <version>${activiti-cloud-service-common.version}</version>
       </dependency>
+      <dependency>
+        <groupId>org.activiti.cloud.common</groupId>
+        <artifactId>activiti-cloud-services-swagger</artifactId>
+        <version>${activiti-cloud-service-common.version}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
   

--- a/activiti-cloud-services-dbp-rest/src/main/java/org/activiti/cloud/alfresco/argument/resolver/AlfrescoPageArgumentMethodResolver.java
+++ b/activiti-cloud-services-dbp-rest/src/main/java/org/activiti/cloud/alfresco/argument/resolver/AlfrescoPageArgumentMethodResolver.java
@@ -21,12 +21,10 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableArgumentResolver;
 import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
 import org.springframework.lang.Nullable;
-import org.springframework.stereotype.Component;
 import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
-@Component
 public class AlfrescoPageArgumentMethodResolver implements PageableArgumentResolver {
 
     private final AlfrescoPageParameterParser pageParameterParser;

--- a/activiti-cloud-services-dbp-rest/src/main/java/org/activiti/cloud/alfresco/argument/resolver/AlfrescoPageParameterParser.java
+++ b/activiti-cloud-services-dbp-rest/src/main/java/org/activiti/cloud/alfresco/argument/resolver/AlfrescoPageParameterParser.java
@@ -16,14 +16,13 @@
 
 package org.activiti.cloud.alfresco.argument.resolver;
 
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.context.request.NativeWebRequest;
 
 public class AlfrescoPageParameterParser {
 
     private final int defaultPageSize;
 
-    public AlfrescoPageParameterParser(@Value("${spring.data.rest.default-page-size:100}") int defaultPageSize) {
+    public AlfrescoPageParameterParser(int defaultPageSize) {
         this.defaultPageSize = defaultPageSize;
     }
 

--- a/activiti-cloud-services-dbp-rest/src/main/java/org/activiti/cloud/alfresco/argument/resolver/AlfrescoPageParameterParser.java
+++ b/activiti-cloud-services-dbp-rest/src/main/java/org/activiti/cloud/alfresco/argument/resolver/AlfrescoPageParameterParser.java
@@ -17,10 +17,8 @@
 package org.activiti.cloud.alfresco.argument.resolver;
 
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Component;
 import org.springframework.web.context.request.NativeWebRequest;
 
-@Component
 public class AlfrescoPageParameterParser {
 
     private final int defaultPageSize;

--- a/activiti-cloud-services-dbp-rest/src/main/java/org/activiti/cloud/alfresco/config/AlfrescoWebAutoConfiguration.java
+++ b/activiti-cloud-services-dbp-rest/src/main/java/org/activiti/cloud/alfresco/config/AlfrescoWebAutoConfiguration.java
@@ -20,29 +20,43 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.activiti.cloud.alfresco.argument.resolver.AlfrescoPageArgumentMethodResolver;
-import org.springframework.context.annotation.ComponentScan;
+import org.activiti.cloud.alfresco.argument.resolver.AlfrescoPageParameterParser;
+import org.activiti.cloud.alfresco.converter.json.AlfrescoJackson2HttpMessageConverter;
+import org.activiti.cloud.alfresco.converter.json.PageMetadataConverter;
+import org.activiti.cloud.alfresco.converter.json.PagedResourcesConverter;
+import org.activiti.cloud.alfresco.data.domain.AlfrescoPagedResourcesAssembler;
+import org.activiti.cloud.alfresco.data.domain.ExtendedPageMetadataConverter;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
+import org.springframework.data.web.HateoasPageableHandlerMethodArgumentResolver;
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
 import org.springframework.hateoas.mvc.TypeConstrainedMappingJackson2HttpMessageConverter;
 import org.springframework.http.MediaType;
 import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.lang.Nullable;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import org.springframework.web.util.UriComponents;
 
 @Configuration
-@ComponentScan(basePackages = "org.activiti.cloud.alfresco")
 @PropertySource("classpath:config/alfresco-rest-config.properties")
 public class AlfrescoWebAutoConfiguration implements WebMvcConfigurer {
 
-    private final AlfrescoPageArgumentMethodResolver alfrescoPageArgumentMethodResolver;
+    private final PageableHandlerMethodArgumentResolver pageableHandlerMethodArgumentResolver;
+    private final int defaultPageSize;
 
-    public AlfrescoWebAutoConfiguration(AlfrescoPageArgumentMethodResolver alfrescoPageArgumentMethodResolver) {
-        this.alfrescoPageArgumentMethodResolver = alfrescoPageArgumentMethodResolver;
+    public AlfrescoWebAutoConfiguration(PageableHandlerMethodArgumentResolver pageableHandlerMethodArgumentResolver,
+                                        @Value("${spring.data.rest.default-page-size:100}") int defaultPageSize) {
+        this.pageableHandlerMethodArgumentResolver = pageableHandlerMethodArgumentResolver;
+        this.defaultPageSize = defaultPageSize;
     }
 
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
-        resolvers.add(0, alfrescoPageArgumentMethodResolver);
+        resolvers.add(0, new AlfrescoPageArgumentMethodResolver(new AlfrescoPageParameterParser(defaultPageSize), pageableHandlerMethodArgumentResolver));
     }
 
     @Override
@@ -58,4 +72,16 @@ public class AlfrescoWebAutoConfiguration implements WebMvcConfigurer {
         }
 
     }
+
+    @Bean
+    public <T> AlfrescoJackson2HttpMessageConverter<T> alfrescoJackson2HttpMessageConverter() {
+        return new AlfrescoJackson2HttpMessageConverter<>(new PagedResourcesConverter(new PageMetadataConverter()));
+    }
+
+    @Bean
+    public <T> AlfrescoPagedResourcesAssembler<T> alfrescoPagedResourcesAssembler(@Autowired(required = false) HateoasPageableHandlerMethodArgumentResolver resolver,
+                                                                                  @Autowired(required = false) UriComponents baseUri){
+        return new AlfrescoPagedResourcesAssembler<>(resolver, baseUri, new ExtendedPageMetadataConverter());
+    }
+
 }

--- a/activiti-cloud-services-dbp-rest/src/main/java/org/activiti/cloud/alfresco/config/AlfrescoWebAutoConfiguration.java
+++ b/activiti-cloud-services-dbp-rest/src/main/java/org/activiti/cloud/alfresco/config/AlfrescoWebAutoConfiguration.java
@@ -36,7 +36,6 @@ import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
 import org.springframework.hateoas.mvc.TypeConstrainedMappingJackson2HttpMessageConverter;
 import org.springframework.http.MediaType;
 import org.springframework.http.converter.HttpMessageConverter;
-import org.springframework.lang.Nullable;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import org.springframework.web.util.UriComponents;

--- a/activiti-cloud-services-dbp-rest/src/main/java/org/activiti/cloud/alfresco/converter/json/AlfrescoJackson2HttpMessageConverter.java
+++ b/activiti-cloud-services-dbp-rest/src/main/java/org/activiti/cloud/alfresco/converter/json/AlfrescoJackson2HttpMessageConverter.java
@@ -20,7 +20,7 @@ import java.io.IOException;
 import java.lang.reflect.Type;
 import java.util.Collections;
 
-import org.activiti.cloud.alfresco.rest.model.AlfrescoContentEntry;
+import org.activiti.cloud.alfresco.rest.model.EntryResponseContent;
 import org.springframework.hateoas.PagedResources;
 import org.springframework.hateoas.Resource;
 import org.springframework.hateoas.Resources;
@@ -29,9 +29,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.converter.HttpMessageNotWritableException;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.lang.Nullable;
-import org.springframework.stereotype.Component;
 
-@Component
 public class AlfrescoJackson2HttpMessageConverter<T> extends MappingJackson2HttpMessageConverter {
 
     private final PagedResourcesConverter pagedResourcesConverter;
@@ -47,13 +45,13 @@ public class AlfrescoJackson2HttpMessageConverter<T> extends MappingJackson2Http
                                  HttpOutputMessage outputMessage) throws IOException, HttpMessageNotWritableException {
         Object transformedObject = object;
         if (object instanceof PagedResources) {
-            transformedObject = pagedResourcesConverter.toAlfrescoContentListWrapper((PagedResources<Resource<T>>) object);
+            transformedObject = pagedResourcesConverter.pagedResourcesToListResponseContent((PagedResources<Resource<T>>)object);
         }
         else if (object instanceof Resources){
-            transformedObject = pagedResourcesConverter.toAlfrescoContentListWrapper((Resources<Resource<T>>) object);
+            transformedObject = pagedResourcesConverter.resourcesToListResponseContent((Resources<Resource<T>>) object);
         }
         else if (object instanceof Resource) {
-            transformedObject = new AlfrescoContentEntry<>(((Resource<T>) object).getContent());
+            transformedObject = new EntryResponseContent<>(((Resource<T>) object).getContent());
         }
         defaultWriteInternal(transformedObject,
                              type,

--- a/activiti-cloud-services-dbp-rest/src/main/java/org/activiti/cloud/alfresco/converter/json/PageMetadataConverter.java
+++ b/activiti-cloud-services-dbp-rest/src/main/java/org/activiti/cloud/alfresco/converter/json/PageMetadataConverter.java
@@ -17,25 +17,23 @@
 package org.activiti.cloud.alfresco.converter.json;
 
 import org.activiti.cloud.alfresco.data.domain.ExtendedPageMetadata;
-import org.activiti.cloud.alfresco.rest.model.AlfrescoPageMetadata;
+import org.activiti.cloud.alfresco.rest.model.PaginationMetadata;
 import org.springframework.hateoas.PagedResources;
-import org.springframework.stereotype.Component;
 
-@Component
 public class PageMetadataConverter {
 
-    public AlfrescoPageMetadata toAlfrescoPageMetadata(PagedResources.PageMetadata basePageMetadata,
-                                                       long count) {
+    public PaginationMetadata toAlfrescoPageMetadata(PagedResources.PageMetadata basePageMetadata,
+                                                     long count) {
         long skipCount = basePageMetadata.getNumber() * basePageMetadata.getSize();
         if (basePageMetadata instanceof ExtendedPageMetadata) {
             skipCount = ((ExtendedPageMetadata) basePageMetadata).getSkipCount();
         }
 
         // the page number starts from zero, so it's necessary to increment by one before comparing with total pages
-        return new AlfrescoPageMetadata(skipCount,
-                                        basePageMetadata.getSize(),
-                                        count,
-                                        basePageMetadata.getTotalPages() > basePageMetadata.getNumber() + 1,
-                                        basePageMetadata.getTotalElements());
+        return new PaginationMetadata(skipCount,
+                                      basePageMetadata.getSize(),
+                                      count,
+                                      basePageMetadata.getTotalPages() > basePageMetadata.getNumber() + 1,
+                                      basePageMetadata.getTotalElements());
     }
 }

--- a/activiti-cloud-services-dbp-rest/src/main/java/org/activiti/cloud/alfresco/converter/json/PagedResourcesConverter.java
+++ b/activiti-cloud-services-dbp-rest/src/main/java/org/activiti/cloud/alfresco/converter/json/PagedResourcesConverter.java
@@ -20,15 +20,13 @@ import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import org.activiti.cloud.alfresco.rest.model.AlfrescoContentEntry;
-import org.activiti.cloud.alfresco.rest.model.AlfrescoPageContentListWrapper;
-import org.activiti.cloud.alfresco.rest.model.AlfrescoPageMetadata;
+import org.activiti.cloud.alfresco.rest.model.EntryResponseContent;
+import org.activiti.cloud.alfresco.rest.model.ListResponseContent;
+import org.activiti.cloud.alfresco.rest.model.PaginationMetadata;
 import org.springframework.hateoas.PagedResources;
 import org.springframework.hateoas.Resource;
 import org.springframework.hateoas.Resources;
-import org.springframework.stereotype.Component;
 
-@Component
 public class PagedResourcesConverter {
 
     private PageMetadataConverter pageMetadataConverter;
@@ -37,28 +35,27 @@ public class PagedResourcesConverter {
         this.pageMetadataConverter = pageMetadataConverter;
     }
 
-    public <T> AlfrescoPageContentListWrapper<T> toAlfrescoContentListWrapper(PagedResources<Resource<T>> pagedResources) {
-        List<AlfrescoContentEntry<T>> baseContent = getAlfrescoContentEntries(pagedResources);
+    public <T> ListResponseContent<T> pagedResourcesToListResponseContent(PagedResources<Resource<T>> pagedResources) {
+        List<EntryResponseContent<T>> baseContent = getAlfrescoContentEntries(pagedResources);
 
-        AlfrescoPageMetadata pagination = pageMetadataConverter.toAlfrescoPageMetadata(pagedResources.getMetadata(),
-                baseContent.size());
+        PaginationMetadata pagination = pageMetadataConverter.toAlfrescoPageMetadata(pagedResources.getMetadata(),
+                                                                                     baseContent.size());
 
-        return AlfrescoPageContentListWrapper.wrap(baseContent,
-                pagination);
+        return ListResponseContent.wrap(baseContent,
+                                        pagination);
     }
 
-    public <T> AlfrescoPageContentListWrapper<T> toAlfrescoContentListWrapper(Resources<Resource<T>> pagedResources) {
-        List<AlfrescoContentEntry<T>> baseContent = getAlfrescoContentEntries(pagedResources);
+    public <T> ListResponseContent<T> resourcesToListResponseContent(Resources<Resource<T>> resources) {
 
-        return AlfrescoPageContentListWrapper.wrap(baseContent,
-                null);
+        return ListResponseContent.wrap(getAlfrescoContentEntries(resources),
+                                        null);
     }
 
-    private <T> List<AlfrescoContentEntry<T>> getAlfrescoContentEntries(Resources<Resource<T>> pagedResources) {
+    private <T> List<EntryResponseContent<T>> getAlfrescoContentEntries(Resources<Resource<T>> pagedResources) {
         Collection<Resource<T>> pagedResourceContent = pagedResources.getContent();
         return pagedResourceContent.stream()
                 .map(
-                        resource -> new AlfrescoContentEntry<>(resource.getContent())
+                        resource -> new EntryResponseContent<>(resource.getContent())
                 ).collect(Collectors.toList());
     }
 }

--- a/activiti-cloud-services-dbp-rest/src/main/java/org/activiti/cloud/alfresco/data/domain/AlfrescoPagedResourcesAssembler.java
+++ b/activiti-cloud-services-dbp-rest/src/main/java/org/activiti/cloud/alfresco/data/domain/AlfrescoPagedResourcesAssembler.java
@@ -25,10 +25,8 @@ import org.springframework.hateoas.PagedResources;
 import org.springframework.hateoas.ResourceAssembler;
 import org.springframework.hateoas.ResourceSupport;
 import org.springframework.lang.Nullable;
-import org.springframework.stereotype.Component;
 import org.springframework.web.util.UriComponents;
 
-@Component
 public class AlfrescoPagedResourcesAssembler<T> extends PagedResourcesAssembler<T> {
 
     private final ExtendedPageMetadataConverter extendedPageMetadataConverter;

--- a/activiti-cloud-services-dbp-rest/src/main/java/org/activiti/cloud/alfresco/data/domain/ExtendedPageMetadataConverter.java
+++ b/activiti-cloud-services-dbp-rest/src/main/java/org/activiti/cloud/alfresco/data/domain/ExtendedPageMetadataConverter.java
@@ -17,9 +17,7 @@
 package org.activiti.cloud.alfresco.data.domain;
 
 import org.springframework.hateoas.PagedResources;
-import org.springframework.stereotype.Component;
 
-@Component
 public class ExtendedPageMetadataConverter {
 
     public ExtendedPageMetadata toExtendedPageMetadata(long skipCount, PagedResources.PageMetadata basePageMetadata) {

--- a/activiti-cloud-services-dbp-rest/src/main/java/org/activiti/cloud/alfresco/rest/model/EntriesResponseContent.java
+++ b/activiti-cloud-services-dbp-rest/src/main/java/org/activiti/cloud/alfresco/rest/model/EntriesResponseContent.java
@@ -17,26 +17,26 @@ package org.activiti.cloud.alfresco.rest.model;
 
 import java.util.List;
 
-public class AlfrescoPageContent<T> {
+public class EntriesResponseContent<T> {
 
-    private List<AlfrescoContentEntry<T>> entries;
+    private List<EntryResponseContent<T>> entries;
 
-    private AlfrescoPageMetadata pagination;
+    private PaginationMetadata pagination;
 
-    public AlfrescoPageContent() {
+    public EntriesResponseContent() {
     }
 
-    public AlfrescoPageContent(List<AlfrescoContentEntry<T>> entries, AlfrescoPageMetadata pagination) {
+    public EntriesResponseContent(List<EntryResponseContent<T>> entries, PaginationMetadata pagination) {
         this.entries = entries;
         this.pagination = pagination;
     }
 
-    public List<AlfrescoContentEntry<T>> getEntries()
+    public List<EntryResponseContent<T>> getEntries()
     {
         return entries;
     }
 
-    public AlfrescoPageMetadata getPagination() {
+    public PaginationMetadata getPagination() {
         return pagination;
     }
 }

--- a/activiti-cloud-services-dbp-rest/src/main/java/org/activiti/cloud/alfresco/rest/model/EntryResponseContent.java
+++ b/activiti-cloud-services-dbp-rest/src/main/java/org/activiti/cloud/alfresco/rest/model/EntryResponseContent.java
@@ -15,14 +15,14 @@
  */
 package org.activiti.cloud.alfresco.rest.model;
 
-public class AlfrescoContentEntry<T>
+public class EntryResponseContent<T>
 {
     private T entry;
 
-    public AlfrescoContentEntry() {
+    public EntryResponseContent() {
     }
 
-    public AlfrescoContentEntry(T entry) {
+    public EntryResponseContent(T entry) {
         this.entry = entry;
     }
 

--- a/activiti-cloud-services-dbp-rest/src/main/java/org/activiti/cloud/alfresco/rest/model/ListResponseContent.java
+++ b/activiti-cloud-services-dbp-rest/src/main/java/org/activiti/cloud/alfresco/rest/model/ListResponseContent.java
@@ -17,24 +17,24 @@ package org.activiti.cloud.alfresco.rest.model;
 
 import java.util.List;
 
-public class AlfrescoPageContentListWrapper<T> {
+public class ListResponseContent<T> {
 
-    private AlfrescoPageContent<T> list;
+    private EntriesResponseContent<T> list;
 
-    public static <T> AlfrescoPageContentListWrapper<T> wrap(List<AlfrescoContentEntry<T>> list, AlfrescoPageMetadata pagination) {
+    public static <T> ListResponseContent<T> wrap(List<EntryResponseContent<T>> list, PaginationMetadata pagination) {
 
-        return new AlfrescoPageContentListWrapper<>(new AlfrescoPageContent<>(list,
-                                                                              pagination));
+        return new ListResponseContent<>(new EntriesResponseContent<>(list,
+                                                                      pagination));
     }
 
-    public AlfrescoPageContentListWrapper() {
+    public ListResponseContent() {
     }
 
-    public AlfrescoPageContentListWrapper(AlfrescoPageContent<T> list) {
+    public ListResponseContent(EntriesResponseContent<T> list) {
         this.list = list;
     }
 
-    public AlfrescoPageContent<T> getList() {
+    public EntriesResponseContent<T> getList() {
         return list;
     }
 

--- a/activiti-cloud-services-dbp-rest/src/main/java/org/activiti/cloud/alfresco/rest/model/PaginationMetadata.java
+++ b/activiti-cloud-services-dbp-rest/src/main/java/org/activiti/cloud/alfresco/rest/model/PaginationMetadata.java
@@ -16,7 +16,7 @@
 
 package org.activiti.cloud.alfresco.rest.model;
 
-public class AlfrescoPageMetadata {
+public class PaginationMetadata {
 
     private long skipCount;
 
@@ -28,14 +28,14 @@ public class AlfrescoPageMetadata {
 
     private long totalItems;
 
-    public AlfrescoPageMetadata() {
+    public PaginationMetadata() {
     }
 
-    public AlfrescoPageMetadata(long skipCount,
-                                long maxItems,
-                                long count,
-                                boolean hasMoreItems,
-                                long totalItems) {
+    public PaginationMetadata(long skipCount,
+                              long maxItems,
+                              long count,
+                              boolean hasMoreItems,
+                              long totalItems) {
         this.skipCount = skipCount;
         this.maxItems = maxItems;
         this.count = count;

--- a/activiti-cloud-services-dbp-rest/src/test/java/org/activiti/cloud/alfresco/config/AlfrescoWebAutoConfigurationTest.java
+++ b/activiti-cloud-services-dbp-rest/src/test/java/org/activiti/cloud/alfresco/config/AlfrescoWebAutoConfigurationTest.java
@@ -24,8 +24,8 @@ import java.util.List;
 import org.activiti.cloud.alfresco.argument.resolver.AlfrescoPageArgumentMethodResolver;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
 import org.springframework.hateoas.MediaTypes;
 import org.springframework.hateoas.Resource;
 import org.springframework.hateoas.mvc.TypeConstrainedMappingJackson2HttpMessageConverter;
@@ -38,19 +38,19 @@ import static org.mockito.MockitoAnnotations.initMocks;
 
 public class AlfrescoWebAutoConfigurationTest {
 
-    @InjectMocks
     private AlfrescoWebAutoConfiguration configurer;
 
     @Mock
-    private AlfrescoPageArgumentMethodResolver alfrescoPageArgumentMethodResolver;
+    private PageableHandlerMethodArgumentResolver pageableHandlerMethodArgumentResolver;
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         initMocks(this);
+        configurer = new AlfrescoWebAutoConfiguration(pageableHandlerMethodArgumentResolver, 100);
     }
 
     @Test
-    public void addArgumentResolversShouldAddAlfrescoPageArgumentMethodResolverAtTheFirstPosition() throws Exception {
+    public void addArgumentResolversShouldAddAlfrescoPageArgumentMethodResolverAtTheFirstPosition() {
         //given
         List<HandlerMethodArgumentResolver> resolvers = new ArrayList<>();
         resolvers.add(mock(HandlerMethodArgumentResolver.class));
@@ -59,11 +59,11 @@ public class AlfrescoWebAutoConfigurationTest {
         configurer.addArgumentResolvers(resolvers);
 
         //then
-        assertThat(resolvers.get(0)).isEqualTo(alfrescoPageArgumentMethodResolver);
+        assertThat(resolvers.get(0)).isInstanceOf(AlfrescoPageArgumentMethodResolver.class);
     }
 
     @Test
-    public void extendMessageConvertersShouldRemoveApplicationJsonFromHalConverter() throws Exception {
+    public void extendMessageConvertersShouldRemoveApplicationJsonFromHalConverter() {
         //given
 
         //when

--- a/activiti-cloud-services-dbp-rest/src/test/java/org/activiti/cloud/alfresco/converter/json/AlfrescoJackson2HttpMessageConverterTest.java
+++ b/activiti-cloud-services-dbp-rest/src/test/java/org/activiti/cloud/alfresco/converter/json/AlfrescoJackson2HttpMessageConverterTest.java
@@ -19,8 +19,8 @@ package org.activiti.cloud.alfresco.converter.json;
 import java.lang.reflect.Type;
 import java.util.List;
 
-import org.activiti.cloud.alfresco.rest.model.AlfrescoContentEntry;
-import org.activiti.cloud.alfresco.rest.model.AlfrescoPageContentListWrapper;
+import org.activiti.cloud.alfresco.rest.model.EntryResponseContent;
+import org.activiti.cloud.alfresco.rest.model.ListResponseContent;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -52,7 +52,7 @@ public class AlfrescoJackson2HttpMessageConverterTest {
     private PagedResourcesConverter pagedResourcesConverter;
 
     @Mock
-    private AlfrescoPageContentListWrapper<String> alfrescoPageContentListWrapper;
+    private ListResponseContent<String> alfrescoPageContentListWrapper;
 
     @Mock
     private PagedResources<Resource<String>> basePagedResources;
@@ -67,17 +67,17 @@ public class AlfrescoJackson2HttpMessageConverterTest {
     private HttpOutputMessage outputMessage;
 
     @Captor
-    private ArgumentCaptor<AlfrescoContentEntry<String>> contentEntryArgumentCaptor;
+    private ArgumentCaptor<EntryResponseContent<String>> contentEntryArgumentCaptor;
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         initMocks(this);
     }
 
     @Test
     public void writeInternalShouldConvertObjectUsingPagedResourcesConverterWhenIsAPagedResources() throws Exception {
         //given
-        given(pagedResourcesConverter.toAlfrescoContentListWrapper(basePagedResources))
+        given(pagedResourcesConverter.pagedResourcesToListResponseContent(basePagedResources))
                 .willReturn(alfrescoPageContentListWrapper);
 
         doNothing().when(httpMessageConverter).defaultWriteInternal(alfrescoPageContentListWrapper,
@@ -99,7 +99,7 @@ public class AlfrescoJackson2HttpMessageConverterTest {
     public void writeInternalShouldConvertWrapContentInsideAlfrescoContentEntryWhenObjectIsAGroupOfResources() throws Exception {
 
         //given
-        given(pagedResourcesConverter.toAlfrescoContentListWrapper(baseResources))
+        given(pagedResourcesConverter.resourcesToListResponseContent(baseResources))
                 .willReturn(alfrescoPageContentListWrapper);
 
         doNothing().when(httpMessageConverter).defaultWriteInternal(alfrescoPageContentListWrapper,
@@ -121,7 +121,7 @@ public class AlfrescoJackson2HttpMessageConverterTest {
     @Test
     public void writeInternalShouldConvertWrapContentInsideAlfrescoContentEntryWhenObjectIsASingleResource() throws Exception {
         //given
-        doNothing().when(httpMessageConverter).defaultWriteInternal(ArgumentMatchers.<AlfrescoContentEntry<?>>any(),
+        doNothing().when(httpMessageConverter).defaultWriteInternal(ArgumentMatchers.<EntryResponseContent<?>>any(),
                                                                     eq(type),
                                                                     eq(outputMessage));
 
@@ -138,7 +138,7 @@ public class AlfrescoJackson2HttpMessageConverterTest {
     }
 
     @Test
-    public void getSupportedMediaTypesShouldReturnApplicationJson() throws Exception {
+    public void getSupportedMediaTypesShouldReturnApplicationJson() {
         //when
         List<MediaType> supportedMediaTypes = httpMessageConverter.getSupportedMediaTypes();
 
@@ -147,7 +147,7 @@ public class AlfrescoJackson2HttpMessageConverterTest {
     }
 
     @Test
-    public void canWriteShouldFalseWhenTypeIsString() throws Exception {
+    public void canWriteShouldFalseWhenTypeIsString() {
         //given
         Class<String> clazz = String.class;
 
@@ -159,7 +159,7 @@ public class AlfrescoJackson2HttpMessageConverterTest {
     }
 
     @Test
-    public void canWriteShouldReturnTrueWhenTypeIsNotStringAndMediaTypeIsApplicationJson() throws Exception {
+    public void canWriteShouldReturnTrueWhenTypeIsNotStringAndMediaTypeIsApplicationJson() {
         //given
         Class<Resource> clazz = Resource.class;
 

--- a/activiti-cloud-services-dbp-rest/src/test/java/org/activiti/cloud/alfresco/converter/json/PageMetadataConverterTest.java
+++ b/activiti-cloud-services-dbp-rest/src/test/java/org/activiti/cloud/alfresco/converter/json/PageMetadataConverterTest.java
@@ -17,7 +17,7 @@
 package org.activiti.cloud.alfresco.converter.json;
 
 import org.activiti.cloud.alfresco.data.domain.ExtendedPageMetadata;
-import org.activiti.cloud.alfresco.rest.model.AlfrescoPageMetadata;
+import org.activiti.cloud.alfresco.rest.model.PaginationMetadata;
 import org.junit.Test;
 import org.springframework.hateoas.PagedResources;
 
@@ -28,15 +28,15 @@ public class PageMetadataConverterTest {
     private PageMetadataConverter converter = new PageMetadataConverter();
 
     @Test
-    public void toAlfrescoPageMetadataShouldCalculateAlfrescoMetadataFromBaseMetadata() throws Exception {
+    public void toAlfrescoPageMetadataShouldCalculateAlfrescoMetadataFromBaseMetadata() {
         //given
         PagedResources.PageMetadata basePageMetadata = new PagedResources.PageMetadata(10,
                                                                                        2,
                                                                                        100);
 
         //when
-        AlfrescoPageMetadata alfrescoPageMetadata = converter.toAlfrescoPageMetadata(basePageMetadata,
-                                                                                     10);
+        PaginationMetadata alfrescoPageMetadata = converter.toAlfrescoPageMetadata(basePageMetadata,
+                                                                                   10);
 
         //then
         assertThat(alfrescoPageMetadata)
@@ -48,15 +48,15 @@ public class PageMetadataConverterTest {
     }
 
     @Test
-    public void toAlfrescoPageMetadataShouldReturnMetadataWithNoMoreItemsWhenIsInTheLastPage() throws Exception {
+    public void toAlfrescoPageMetadataShouldReturnMetadataWithNoMoreItemsWhenIsInTheLastPage() {
         //given
         PagedResources.PageMetadata basePageMetadata = new PagedResources.PageMetadata(10,
                                                                                        1,
                                                                                        11);
 
         //when
-        AlfrescoPageMetadata alfrescoPageMetadata = converter.toAlfrescoPageMetadata(basePageMetadata,
-                                                                                     10);
+        PaginationMetadata alfrescoPageMetadata = converter.toAlfrescoPageMetadata(basePageMetadata,
+                                                                                   10);
 
         //then
         assertThat(alfrescoPageMetadata)
@@ -64,7 +64,7 @@ public class PageMetadataConverterTest {
     }
 
     @Test
-    public void toAlfrescoPageMetadataShouldUseSkipCountFromExtendedPageMetadataWhenAvailable() throws Exception {
+    public void toAlfrescoPageMetadataShouldUseSkipCountFromExtendedPageMetadataWhenAvailable() {
         //given
         ExtendedPageMetadata baseMetadata = new ExtendedPageMetadata(3,
                                                                      10,
@@ -73,8 +73,8 @@ public class PageMetadataConverterTest {
                                                                      2);
 
         //when
-        AlfrescoPageMetadata alfrescoPageMetadata = converter.toAlfrescoPageMetadata(baseMetadata,
-                                                                                     5);
+        PaginationMetadata alfrescoPageMetadata = converter.toAlfrescoPageMetadata(baseMetadata,
+                                                                                   5);
 
         //then
         assertThat(alfrescoPageMetadata).hasSkipCount(3);

--- a/activiti-cloud-services-dbp-rest/src/test/java/org/activiti/cloud/alfresco/converter/json/PagedResourcesConverterTest.java
+++ b/activiti-cloud-services-dbp-rest/src/test/java/org/activiti/cloud/alfresco/converter/json/PagedResourcesConverterTest.java
@@ -19,9 +19,9 @@ package org.activiti.cloud.alfresco.converter.json;
 import java.util.Collections;
 import java.util.List;
 
-import org.activiti.cloud.alfresco.rest.model.AlfrescoContentEntry;
-import org.activiti.cloud.alfresco.rest.model.AlfrescoPageContentListWrapper;
-import org.activiti.cloud.alfresco.rest.model.AlfrescoPageMetadata;
+import org.activiti.cloud.alfresco.rest.model.EntryResponseContent;
+import org.activiti.cloud.alfresco.rest.model.ListResponseContent;
+import org.activiti.cloud.alfresco.rest.model.PaginationMetadata;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.InjectMocks;
@@ -43,46 +43,46 @@ public class PagedResourcesConverterTest {
     private PageMetadataConverter pageMetadataConverter;
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         initMocks(this);
     }
 
     @Test
-    public void toAlfrescoContentListWrapperShouldConvertFromPagedResourcesToAlfrescoContentListWrapper() throws Exception {
+    public void toAlfrescoContentListWrapperShouldConvertFromPagedResourcesToAlfrescoContentListWrapper() {
         //given
         List<Resource<String>> elements = Collections.singletonList(new Resource<>("any"));
         PagedResources.PageMetadata basePageMetaData = new PagedResources.PageMetadata(10,
                                                                                1,
                                                                                100);
 
-        AlfrescoPageMetadata alfrescoPageMetadata = new AlfrescoPageMetadata();
+        PaginationMetadata alfrescoPageMetadata = new PaginationMetadata();
         given(pageMetadataConverter.toAlfrescoPageMetadata(basePageMetaData, elements.size())).willReturn(alfrescoPageMetadata);
 
         //when
-        AlfrescoPageContentListWrapper<String> alfrescoPageContentListWrapper = pagedResourcesConverter.toAlfrescoContentListWrapper(new PagedResources<>(elements,
-                                                                                                                                                          basePageMetaData));
+        ListResponseContent<String> alfrescoPageContentListWrapper = pagedResourcesConverter.pagedResourcesToListResponseContent(new PagedResources<>(elements,
+                                                                                                                                                      basePageMetaData));
 
         //then
         assertThat(alfrescoPageContentListWrapper).isNotNull();
         assertThat(alfrescoPageContentListWrapper.getList().getEntries())
-                .extracting(AlfrescoContentEntry::getEntry)
+                .extracting(EntryResponseContent::getEntry)
                 .containsExactly("any");
         assertThat(alfrescoPageContentListWrapper.getList().getPagination()).isEqualTo(alfrescoPageMetadata);
 
     }
 
     @Test
-    public void toAlfrescoContentListWrapperShouldConvertFromResourcesToAlfrescoContentListWrapper() throws Exception {
+    public void toAlfrescoContentListWrapperShouldConvertFromResourcesToAlfrescoContentListWrapper() {
         //given
         List<Resource<String>> elements = Collections.singletonList(new Resource<>("any"));
 
         //when
-        AlfrescoPageContentListWrapper<String> alfrescoPageContentListWrapper = pagedResourcesConverter.toAlfrescoContentListWrapper(new Resources<>(elements));
+        ListResponseContent<String> alfrescoPageContentListWrapper = pagedResourcesConverter.resourcesToListResponseContent(new Resources<>(elements));
 
         //then
         assertThat(alfrescoPageContentListWrapper).isNotNull();
         assertThat(alfrescoPageContentListWrapper.getList().getEntries())
-                .extracting(AlfrescoContentEntry::getEntry)
+                .extracting(EntryResponseContent::getEntry)
                 .containsExactly("any");
     }
 

--- a/activiti-cloud-services-swagger/README.md
+++ b/activiti-cloud-services-swagger/README.md
@@ -1,0 +1,30 @@
+# Activiti Cloud Services Swagger
+
+This module provides base springfox configuration for swagger auto-generated specification file. It provides two
+swagger specification files: 
+
+- default: available under `v2/api-docs` or `v2/api-docs?group=default`;
+ provides specification for Alfresco MediaType format
+
+- HAL: available under `v2/api-docs?group=hal`; provides specification for HAL format
+
+## How to use it
+- Add a Maven dependency to this project:
+
+```xml
+<dependency>
+  <groupId>org.activiti.cloud.common</groupId>
+  <artifactId>activiti-cloud-services-swagger</artifactId>
+</dependency>
+```
+- Declare a bean the will select the apis to be scanned. I.e.:
+```
+@Bean
+public Predicate<RequestHandler> apiSelector() {
+    return RequestHandlerSelectors.basePackage("org.activiti.cloud.services")::apply;
+}
+```
+
+*Note:* make sure the controllers are returning Spring objects only (`PagedResources<Resource<DomainObject>>`, 
+`Resources<Resource<DomainObject>>`, `Resource<DomainObject>`); the mapping will not work if custom `*Resource` 
+are used.

--- a/activiti-cloud-services-swagger/pom.xml
+++ b/activiti-cloud-services-swagger/pom.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>activiti-cloud-service-common-dependencies</artifactId>
+        <groupId>org.activiti.cloud.common</groupId>
+        <version>7.1.0-SNAPSHOT</version>
+        <relativePath>../activiti-cloud-service-common-dependencies</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>activiti-cloud-services-swagger</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.activiti.cloud.common</groupId>
+            <artifactId>activiti-cloud-services-dbp-rest</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.springfox</groupId>
+            <artifactId>springfox-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.springfox</groupId>
+            <artifactId>springfox-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.springfox</groupId>
+            <artifactId>springfox-spring-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.springfox</groupId>
+            <artifactId>springfox-swagger2</artifactId>
+        </dependency>
+    </dependencies>
+
+
+
+</project>

--- a/activiti-cloud-services-swagger/src/main/java/org/activiti/cloud/common/swagger/DocketCustomizer.java
+++ b/activiti-cloud-services-swagger/src/main/java/org/activiti/cloud/common/swagger/DocketCustomizer.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2019 Alfresco, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.cloud.common.swagger;
+
+import springfox.documentation.spring.web.plugins.Docket;
+
+public interface DocketCustomizer {
+
+    Docket customize(Docket docket);
+
+}

--- a/activiti-cloud-services-swagger/src/main/java/org/activiti/cloud/common/swagger/SwaggerDocketBuilder.java
+++ b/activiti-cloud-services-swagger/src/main/java/org/activiti/cloud/common/swagger/SwaggerDocketBuilder.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2019 Alfresco, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.cloud.common.swagger;
+
+import java.lang.reflect.Type;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Predicate;
+
+import com.fasterxml.classmate.ResolvedType;
+import com.fasterxml.classmate.TypeResolver;
+import org.activiti.cloud.alfresco.rest.model.EntryResponseContent;
+import org.activiti.cloud.alfresco.rest.model.ListResponseContent;
+import org.springframework.core.Ordered;
+import org.springframework.data.domain.Pageable;
+import org.springframework.hateoas.PagedResources;
+import org.springframework.hateoas.Resource;
+import org.springframework.hateoas.Resources;
+import springfox.documentation.RequestHandler;
+import springfox.documentation.builders.AlternateTypeBuilder;
+import springfox.documentation.builders.AlternateTypePropertyBuilder;
+import springfox.documentation.builders.PathSelectors;
+import springfox.documentation.schema.WildcardType;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spring.web.plugins.Docket;
+
+import static springfox.documentation.schema.AlternateTypeRules.newRule;
+
+public class SwaggerDocketBuilder {
+
+    private final TypeResolver typeResolver;
+    private final List<DocketCustomizer> docketCustomizers;
+
+    public SwaggerDocketBuilder(TypeResolver typeResolver,
+                                List<DocketCustomizer> docketCustomizers) {
+        this.typeResolver = typeResolver;
+        this.docketCustomizers = docketCustomizers;
+    }
+
+    public Docket buildHalAPIDocket(Predicate<RequestHandler> apiSelector) {
+        Docket docket = new Docket(DocumentationType.SWAGGER_2)
+                .groupName("hal")
+                .select()
+                .apis(apiSelector::test)
+                .paths(PathSelectors.any())
+                .build();
+        return applyCustomizations(docket);
+    }
+
+    private Docket applyCustomizations(Docket docket) {
+        Docket customizedDocket = docket;
+        if (docketCustomizers != null){
+            for (DocketCustomizer docketCustomizer : docketCustomizers) {
+                customizedDocket = docketCustomizer.customize(customizedDocket);
+            }
+        }
+        return customizedDocket;
+    }
+
+    public Docket buildAlfrescoAPIDocket(Predicate<RequestHandler> apiSelector) {
+        ResolvedType resourceTypeWithWildCard = typeResolver.resolve(Resource.class,
+                                                                     WildcardType.class);
+        Docket docket = new Docket(DocumentationType.SWAGGER_2)
+                .alternateTypeRules(newRule(typeResolver.resolve(Resources.class,
+                                                                 resourceTypeWithWildCard),
+                                            typeResolver.resolve(ListResponseContent.class,
+                                                                 WildcardType.class)))
+                .alternateTypeRules(newRule(typeResolver.resolve(PagedResources.class,
+                                                                 resourceTypeWithWildCard),
+                                            typeResolver.resolve(ListResponseContent.class,
+                                                                 WildcardType.class)))
+                .alternateTypeRules(newRule(resourceTypeWithWildCard,
+                                            typeResolver.resolve(EntryResponseContent.class,
+                                                                 WildcardType.class)))
+                .alternateTypeRules(newRule(typeResolver.resolve(Pageable.class),
+                                            pageableMixin(),
+                                            Ordered.HIGHEST_PRECEDENCE))
+                .select()
+                .apis(apiSelector::test)
+                .paths(PathSelectors.any())
+                .build();
+        return applyCustomizations(docket);
+    }
+
+    private Type pageableMixin() {
+        return new AlternateTypeBuilder()
+                .fullyQualifiedClassName(
+                        String.format("%s.generated.%s",
+                                      Pageable.class.getPackage().getName(),
+                                      Pageable.class.getSimpleName()))
+                .withProperties(Arrays.asList(
+                        property(Integer.class,
+                                 "skipCount"),
+                        property(Integer.class,
+                                 "maxItems"),
+                        property(String.class,
+                                 "sort")
+                ))
+                .build();
+    }
+
+    private AlternateTypePropertyBuilder property(Class<?> type, String name) {
+        return new AlternateTypePropertyBuilder()
+                .withName(name)
+                .withType(type)
+                .withCanRead(true)
+                .withCanWrite(true);
+    }
+
+}

--- a/activiti-cloud-services-swagger/src/main/java/org/activiti/cloud/common/swagger/conf/SwaggerAutoConfiguration.java
+++ b/activiti-cloud-services-swagger/src/main/java/org/activiti/cloud/common/swagger/conf/SwaggerAutoConfiguration.java
@@ -16,9 +16,7 @@
 
 package org.activiti.cloud.common.swagger.conf;
 
-import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 import java.util.function.Predicate;
 
 import com.fasterxml.classmate.TypeResolver;

--- a/activiti-cloud-services-swagger/src/main/java/org/activiti/cloud/common/swagger/conf/SwaggerAutoConfiguration.java
+++ b/activiti-cloud-services-swagger/src/main/java/org/activiti/cloud/common/swagger/conf/SwaggerAutoConfiguration.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2019 Alfresco, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.cloud.common.swagger.conf;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Predicate;
+
+import com.fasterxml.classmate.TypeResolver;
+import org.activiti.cloud.common.swagger.DocketCustomizer;
+import org.activiti.cloud.common.swagger.SwaggerDocketBuilder;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import springfox.documentation.RequestHandler;
+import springfox.documentation.spring.web.plugins.Docket;
+import springfox.documentation.swagger2.annotations.EnableSwagger2;
+
+/**
+ * Provides base springfox configuration for swagger auto-generated specification file. It provides two
+ * swagger specification files: the default one is available under `v2/api-docs` or `v2/api-docs?group=default`
+ * and provides specification for Alfresco MediaType format; the HAL one is available under `v2/api-docs?group=hal`
+ * and provides specification for HAL format
+ *
+ * This configuration is not self-contained: the one adding this as dependency should provide a bean of type
+ * {@link Predicate<RequestHandler>} that will be injected under {@link Docket#select()}. I.e
+ * <code>test</code>
+ * {@code test}
+ * <pre>
+ *     &#64;Bean
+ *     public Predicate&#60;RequestHandler&#62; apiSelector() {
+ *         return RequestHandlerSelectors.basePackage("org.activiti.cloud.services")::apply;
+ *     }
+ *  </pre>
+ */
+@Configuration
+@EnableSwagger2
+public class SwaggerAutoConfiguration {
+
+    private Predicate<RequestHandler> apiSelector;
+
+    private List<DocketCustomizer> docketCustomizers;
+
+
+    public SwaggerAutoConfiguration(Predicate<RequestHandler> apiSelector,
+                                    @Autowired(required = false) List<DocketCustomizer> docketCustomizers) {
+        this.apiSelector = apiSelector;
+        this.docketCustomizers = docketCustomizers;
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public SwaggerDocketBuilder swaggerDocketBuilder(TypeResolver typeResolver){
+        return new SwaggerDocketBuilder(typeResolver,
+                                        docketCustomizers);
+    }
+
+    @Bean(name = "halAPIDocket")
+    @ConditionalOnMissingBean(name = "halAPIDocket")
+    public Docket halAPIDocket(SwaggerDocketBuilder swaggerDocketBuilder) {
+        return swaggerDocketBuilder.buildHalAPIDocket(apiSelector);
+    }
+
+    @Bean(name = "alfrescoAPIDocket")
+    @ConditionalOnMissingBean(name = "alfrescoAPIDocket")
+    public Docket alfrescoAPIDocket(SwaggerDocketBuilder swaggerDocketBuilder) {
+        return swaggerDocketBuilder.buildAlfrescoAPIDocket(apiSelector);
+    }
+
+
+}

--- a/activiti-cloud-services-swagger/src/main/resources/META-INF/spring.factories
+++ b/activiti-cloud-services-swagger/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+  org.activiti.cloud.common.swagger.conf.SwaggerAutoConfiguration

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,7 @@
     <module>activiti-cloud-services-commons-io</module>
     <module>activiti-cloud-services-common-security</module>
     <module>activiti-cloud-service-common-config</module>
+    <module>activiti-cloud-services-swagger</module>
   </modules>
   <scm>
     <url>https://github.com/Activiti/activiti-cloud-service-common</url>


### PR DESCRIPTION
Map `PagedResources`, `Resources` and `Resource` spring objects to the equivalent alfresco type.
Two swagger specifications are provided:
- default (alfresco) -> `v2/api-docs`
- HAL: -> `v2/api-docs?group=hal`

Ref https://github.com/Activiti/Activiti/issues/2588