### PR TITLE
refactor(build): removed component scans configurations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ hs_err_pid*
 .updatebot-repos/**
 
 *.versionsBackup
+
+.factorypath

--- a/activiti-cloud-service-error-handlers/pom.xml
+++ b/activiti-cloud-service-error-handlers/pom.xml
@@ -18,6 +18,10 @@
             <artifactId>spring-web</artifactId>
         </dependency>
         <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.hateoas</groupId>
             <artifactId>spring-hateoas</artifactId>
         </dependency>

--- a/activiti-cloud-services-common-identity-keycloak/pom.xml
+++ b/activiti-cloud-services-common-identity-keycloak/pom.xml
@@ -16,10 +16,6 @@
       <artifactId>activiti-api-runtime-shared</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-web</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.springframework.hateoas</groupId>
       <artifactId>spring-hateoas</artifactId>
     </dependency>
@@ -55,11 +51,11 @@
       <groupId>org.springframework</groupId>
       <artifactId>spring-context</artifactId>
     </dependency>
-
     <dependency>
       <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-security</artifactId>
-    </dependency>
+      <artifactId>spring-boot-configuration-processor</artifactId>
+      <optional>true</optional>
+    </dependency>    
     <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>

--- a/activiti-cloud-services-common-identity-keycloak/src/main/java/org/activiti/cloud/services/identity/keycloak/ActivitiKeycloakProperties.java
+++ b/activiti-cloud-services-common-identity-keycloak/src/main/java/org/activiti/cloud/services/identity/keycloak/ActivitiKeycloakProperties.java
@@ -1,10 +1,8 @@
 package org.activiti.cloud.services.identity.keycloak;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.stereotype.Component;
 
 @ConfigurationProperties(prefix = "activiti.keycloak")
-@Component
 public class ActivitiKeycloakProperties {
 
     private String adminClientApp;

--- a/activiti-cloud-services-common-identity-keycloak/src/main/java/org/activiti/cloud/services/identity/keycloak/KeycloakInstanceWrapper.java
+++ b/activiti-cloud-services-common-identity-keycloak/src/main/java/org/activiti/cloud/services/identity/keycloak/KeycloakInstanceWrapper.java
@@ -4,9 +4,7 @@ package org.activiti.cloud.services.identity.keycloak;
 import org.keycloak.admin.client.Keycloak;
 import org.keycloak.admin.client.resource.RealmResource;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
 
-@Component
 public class KeycloakInstanceWrapper {
 
     @Autowired

--- a/activiti-cloud-services-common-identity-keycloak/src/main/java/org/activiti/cloud/services/identity/keycloak/KeycloakProperties.java
+++ b/activiti-cloud-services-common-identity-keycloak/src/main/java/org/activiti/cloud/services/identity/keycloak/KeycloakProperties.java
@@ -1,10 +1,8 @@
 package org.activiti.cloud.services.identity.keycloak;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.stereotype.Component;
 
 @ConfigurationProperties(prefix = "keycloak")
-@Component
 public class KeycloakProperties {
 
     private String authServerUrl;

--- a/activiti-cloud-services-common-security-keycloak/pom.xml
+++ b/activiti-cloud-services-common-security-keycloak/pom.xml
@@ -16,8 +16,12 @@
       <artifactId>activiti-api-runtime-shared</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-security</artifactId>
+      <groupId>org.springframework.security</groupId>
+      <artifactId>spring-security-config</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.security</groupId>
+      <artifactId>spring-security-web</artifactId>
     </dependency>
     <dependency>
       <groupId>org.keycloak</groupId>

--- a/activiti-cloud-services-common-security-keycloak/src/main/java/org/activiti/cloud/services/common/security/keycloak/KeycloakSecurityContextTokenProvider.java
+++ b/activiti-cloud-services-common-security-keycloak/src/main/java/org/activiti/cloud/services/common/security/keycloak/KeycloakSecurityContextTokenProvider.java
@@ -16,22 +16,18 @@
 
 package org.activiti.cloud.services.common.security.keycloak;
 
-import java.util.Optional;
-
 import org.activiti.api.runtime.shared.security.SecurityContextTokenProvider;
 import org.keycloak.KeycloakPrincipal;
 import org.keycloak.KeycloakSecurityContext;
-import org.springframework.context.annotation.Primary;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.stereotype.Component;
+
+import java.util.Optional;
 
 /**
  * Keycloak implementation for {@link SecurityContextTokenProvider}
  */
-@Component
-@Primary
 public class KeycloakSecurityContextTokenProvider implements SecurityContextTokenProvider {
 
     @Override

--- a/activiti-cloud-services-common-security-keycloak/src/main/java/org/activiti/cloud/services/common/security/keycloak/KeycloakSecurityManagerImpl.java
+++ b/activiti-cloud-services-common-security-keycloak/src/main/java/org/activiti/cloud/services/common/security/keycloak/KeycloakSecurityManagerImpl.java
@@ -2,12 +2,8 @@ package org.activiti.cloud.services.common.security.keycloak;
 
 import org.activiti.api.runtime.shared.security.SecurityManager;
 import org.keycloak.KeycloakPrincipal;
-import org.springframework.context.annotation.Primary;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.stereotype.Component;
 
-@Component
-@Primary
 public class KeycloakSecurityManagerImpl implements SecurityManager {
 
     @Override

--- a/activiti-cloud-services-common-security-keycloak/src/main/java/org/activiti/cloud/services/common/security/keycloak/config/CommonSecurityAutoConfiguration.java
+++ b/activiti-cloud-services-common-security-keycloak/src/main/java/org/activiti/cloud/services/common/security/keycloak/config/CommonSecurityAutoConfiguration.java
@@ -43,6 +43,8 @@ import org.springframework.security.web.authentication.session.SessionAuthentica
 @ConditionalOnWebApplication
 @ConditionalOnMissingBean(value = {KeycloakConfigResolver.class, SessionAuthenticationStrategy.class, SessionAuthenticationStrategy.class})
 public class CommonSecurityAutoConfiguration extends KeycloakWebSecurityConfigurerAdapter {
+    
+    private KeycloakAuthenticationProvider keycloakAuthenticationProvider = new KeycloakAuthenticationProvider();
 
     /**
      * Registers the KeycloakAuthenticationProvider with the authentication manager.
@@ -102,5 +104,11 @@ public class CommonSecurityAutoConfiguration extends KeycloakWebSecurityConfigur
         super.configure(http);
         http.authorizeRequests()
                 .anyRequest().permitAll().and().csrf().disable().httpBasic().disable();
+    }
+
+    
+    @Autowired(required = false)
+    public void setKeycloakAuthenticationProvider(KeycloakAuthenticationProvider keycloakAuthenticationProvider) {
+        this.keycloakAuthenticationProvider = keycloakAuthenticationProvider;
     }
 }

--- a/activiti-cloud-services-common-security-keycloak/src/main/java/org/activiti/cloud/services/common/security/keycloak/config/CommonSecurityAutoConfiguration.java
+++ b/activiti-cloud-services-common-security-keycloak/src/main/java/org/activiti/cloud/services/common/security/keycloak/config/CommonSecurityAutoConfiguration.java
@@ -54,23 +54,27 @@ public class CommonSecurityAutoConfiguration extends KeycloakWebSecurityConfigur
         auth.authenticationProvider(keycloakAuthenticationProvider);
     }
 
+    @Override
     protected KeycloakAuthenticationProvider keycloakAuthenticationProvider() {
-        return new KeycloakAuthenticationProvider();
+        return keycloakAuthenticationProvider;
     }
     
     @Bean
     @Primary
+    @ConditionalOnMissingBean
     public SecurityManager securityManager() {
         return new KeycloakSecurityManagerImpl();
     }
     
     @Bean
     @Primary
+    @ConditionalOnMissingBean
     public SecurityContextTokenProvider securityContextTokenProvider () {
         return new KeycloakSecurityContextTokenProvider();
     }
     
     @Bean
+    @ConditionalOnMissingBean
     public KeycloakConfigResolver KeycloakConfigResolver() {
         return new KeycloakSpringBootConfigResolver();
     }
@@ -88,6 +92,7 @@ public class CommonSecurityAutoConfiguration extends KeycloakWebSecurityConfigur
      */
     @Bean
     @Override
+    @ConditionalOnMissingBean
     protected SessionAuthenticationStrategy sessionAuthenticationStrategy() {
         return new RegisterSessionAuthenticationStrategy(new SessionRegistryImpl());
     }

--- a/activiti-cloud-services-common-security-keycloak/src/main/java/org/activiti/cloud/services/common/security/keycloak/config/CommonSecurityAutoConfiguration.java
+++ b/activiti-cloud-services-common-security-keycloak/src/main/java/org/activiti/cloud/services/common/security/keycloak/config/CommonSecurityAutoConfiguration.java
@@ -30,7 +30,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Primary;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.core.authority.mapping.SimpleAuthorityMapper;
@@ -62,14 +61,12 @@ public class CommonSecurityAutoConfiguration extends KeycloakWebSecurityConfigur
     }
     
     @Bean
-    @Primary
     @ConditionalOnMissingBean
     public SecurityManager securityManager() {
         return new KeycloakSecurityManagerImpl();
     }
     
     @Bean
-    @Primary
     @ConditionalOnMissingBean
     public SecurityContextTokenProvider securityContextTokenProvider () {
         return new KeycloakSecurityContextTokenProvider();

--- a/activiti-cloud-services-common-security-keycloak/src/main/java/org/activiti/cloud/services/common/security/keycloak/config/CommonSecurityAutoConfiguration.java
+++ b/activiti-cloud-services-common-security-keycloak/src/main/java/org/activiti/cloud/services/common/security/keycloak/config/CommonSecurityAutoConfiguration.java
@@ -15,29 +15,32 @@ package org.activiti.cloud.services.common.security.keycloak.config;/*
  */
 
 
+import org.activiti.api.runtime.shared.security.SecurityContextTokenProvider;
+import org.activiti.api.runtime.shared.security.SecurityManager;
+import org.activiti.cloud.services.common.security.keycloak.KeycloakSecurityContextTokenProvider;
+import org.activiti.cloud.services.common.security.keycloak.KeycloakSecurityManagerImpl;
 import org.keycloak.adapters.KeycloakConfigResolver;
 import org.keycloak.adapters.springboot.KeycloakSpringBootConfigResolver;
-import org.keycloak.adapters.springsecurity.KeycloakSecurityComponents;
+import org.keycloak.adapters.springsecurity.KeycloakConfiguration;
 import org.keycloak.adapters.springsecurity.authentication.KeycloakAuthenticationProvider;
 import org.keycloak.adapters.springsecurity.config.KeycloakWebSecurityConfigurerAdapter;
 import org.keycloak.adapters.springsecurity.management.HttpSessionManager;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Primary;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.core.authority.mapping.SimpleAuthorityMapper;
 import org.springframework.security.core.session.SessionRegistryImpl;
 import org.springframework.security.web.authentication.session.RegisterSessionAuthenticationStrategy;
 import org.springframework.security.web.authentication.session.SessionAuthenticationStrategy;
 
 @Configuration
-@ComponentScan(basePackageClasses = KeycloakSecurityComponents.class)
+@KeycloakConfiguration
+@ConditionalOnWebApplication
 @ConditionalOnMissingBean(value = {KeycloakConfigResolver.class, SessionAuthenticationStrategy.class, SessionAuthenticationStrategy.class})
 public class CommonSecurityAutoConfiguration extends KeycloakWebSecurityConfigurerAdapter {
 
@@ -54,7 +57,19 @@ public class CommonSecurityAutoConfiguration extends KeycloakWebSecurityConfigur
     protected KeycloakAuthenticationProvider keycloakAuthenticationProvider() {
         return new KeycloakAuthenticationProvider();
     }
-
+    
+    @Bean
+    @Primary
+    public SecurityManager securityManager() {
+        return new KeycloakSecurityManagerImpl();
+    }
+    
+    @Bean
+    @Primary
+    public SecurityContextTokenProvider securityContextTokenProvider () {
+        return new KeycloakSecurityContextTokenProvider();
+    }
+    
     @Bean
     public KeycloakConfigResolver KeycloakConfigResolver() {
         return new KeycloakSpringBootConfigResolver();

--- a/activiti-cloud-services-commons-io/pom.xml
+++ b/activiti-cloud-services-commons-io/pom.xml
@@ -29,8 +29,12 @@
   <name>Activiti Cloud Services :: Commons IO</name>
   <dependencies>
     <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-web</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-web</artifactId>
+      <artifactId>spring-boot</artifactId>
     </dependency>
     <dependency>
       <groupId>org.springframework.data</groupId>

--- a/activiti-cloud-services-dbp-rest/pom.xml
+++ b/activiti-cloud-services-dbp-rest/pom.xml
@@ -16,10 +16,6 @@
       <artifactId>spring-hateoas</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-data-rest</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.springframework.data</groupId>
       <artifactId>spring-data-rest-webmvc</artifactId>
     </dependency>

--- a/activiti-cloud-services-metadata/pom.xml
+++ b/activiti-cloud-services-metadata/pom.xml
@@ -28,6 +28,7 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-autoconfigure</artifactId>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.assertj</groupId>

--- a/activiti-cloud-services-metadata/src/main/java/org/activiti/cloud/services/metadata/ActivitiMetadataAutoConfiguration.java
+++ b/activiti-cloud-services-metadata/src/main/java/org/activiti/cloud/services/metadata/ActivitiMetadataAutoConfiguration.java
@@ -1,6 +1,5 @@
 package org.activiti.cloud.services.metadata;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -14,12 +13,9 @@ import org.springframework.context.annotation.PropertySource;
 @PropertySource(value = "classpath:metadata.properties",ignoreResourceNotFound = true)
 public class ActivitiMetadataAutoConfiguration {
 
-    @Autowired
-    private MetadataProperties metadataProperties;
-
     @Bean
     @ConditionalOnMissingBean(MetadataService.class)
-    MetadataService metadataService(){
+    public MetadataService metadataService(MetadataProperties metadataProperties){
         return new MetadataService(metadataProperties);
     }
 }

--- a/activiti-cloud-services-metadata/src/main/java/org/activiti/cloud/services/metadata/MetadataProperties.java
+++ b/activiti-cloud-services-metadata/src/main/java/org/activiti/cloud/services/metadata/MetadataProperties.java
@@ -2,13 +2,11 @@ package org.activiti.cloud.services.metadata;
 
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.stereotype.Component;
 
 import java.util.HashMap;
 import java.util.Map;
 
 @ConfigurationProperties("activiti.cloud")
-@Component
 public class MetadataProperties implements InitializingBean {
 
     private Map<String, String> application = new HashMap<String, String>();

--- a/activiti-cloud-services-metadata/src/main/java/org/activiti/cloud/services/metadata/MetadataService.java
+++ b/activiti-cloud-services-metadata/src/main/java/org/activiti/cloud/services/metadata/MetadataService.java
@@ -1,13 +1,11 @@
 package org.activiti.cloud.services.metadata;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
 
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 
-@Component
 public class MetadataService {
 
     private MetadataProperties metadataProperties;

--- a/activiti-cloud-services-swagger/pom.xml
+++ b/activiti-cloud-services-swagger/pom.xml
@@ -14,6 +14,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-autoconfigure</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
         </dependency>

--- a/activiti-cloud-services-test/pom.xml
+++ b/activiti-cloud-services-test/pom.xml
@@ -80,9 +80,9 @@
       <artifactId>spring-mock-mvc</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-hateoas</artifactId>
-    </dependency>
+      <groupId>org.springframework.plugin</groupId>
+      <artifactId>spring-plugin-core</artifactId>
+    </dependency>    
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>

--- a/activiti-cloud-services-test/src/main/java/org/activiti/cloud/services/test/TestConfiguration.java
+++ b/activiti-cloud-services-test/src/main/java/org/activiti/cloud/services/test/TestConfiguration.java
@@ -21,26 +21,38 @@ import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.activiti.cloud.services.identity.keycloak.KeycloakProperties;
 import org.activiti.cloud.services.test.identity.keycloak.interceptor.KeycloakTokenProducer;
+import org.activiti.cloud.starters.test.MyProducer;
+import org.activiti.cloud.starters.test.StreamProducer;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.cloud.stream.annotation.EnableBinding;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.hateoas.MediaTypes;
 import org.springframework.hateoas.hal.Jackson2HalModule;
 import org.springframework.http.converter.StringHttpMessageConverter;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.messaging.MessageChannel;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
 
 @Configuration
+@EnableBinding(StreamProducer.class)
 public class TestConfiguration {
 
     private final List<Module> modules;
 
     public TestConfiguration(List<Module> modules) {
         this.modules = modules;
+    }
+    
+    
+    @Bean
+    @ConditionalOnMissingBean
+    public MyProducer myProducer(MessageChannel producer) {
+        return new MyProducer(producer);
     }
     
     @Bean
@@ -54,7 +66,9 @@ public class TestConfiguration {
         ObjectMapper mapper = new ObjectMapper();
         mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES,
                          false);
+        
         mapper.registerModule(new Jackson2HalModule());
+        
         for (Module module : modules) {
             if (module.getModuleName().startsWith("map")) {
                 mapper.registerModule(module);
@@ -69,4 +83,5 @@ public class TestConfiguration {
                 jackson2HttpMessageConverter,
                 new StringHttpMessageConverter(StandardCharsets.UTF_8)).additionalInterceptors(keycloakTokenProducer);
     }
+    
 }

--- a/activiti-cloud-services-test/src/main/java/org/activiti/cloud/services/test/TestConfiguration.java
+++ b/activiti-cloud-services-test/src/main/java/org/activiti/cloud/services/test/TestConfiguration.java
@@ -23,22 +23,26 @@ import org.activiti.cloud.services.identity.keycloak.KeycloakProperties;
 import org.activiti.cloud.services.test.identity.keycloak.interceptor.KeycloakTokenProducer;
 import org.activiti.cloud.starters.test.MyProducer;
 import org.activiti.cloud.starters.test.StreamProducer;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.web.client.RestTemplateAutoConfiguration;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.cloud.stream.annotation.EnableBinding;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.hateoas.MediaTypes;
 import org.springframework.hateoas.hal.Jackson2HalModule;
+import org.springframework.http.MediaType;
 import org.springframework.http.converter.StringHttpMessageConverter;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.messaging.MessageChannel;
 
 import java.nio.charset.StandardCharsets;
-import java.util.Collections;
+import java.util.Arrays;
 import java.util.List;
 
 @Configuration
+@AutoConfigureBefore(value=RestTemplateAutoConfiguration.class)
 @EnableBinding(StreamProducer.class)
 public class TestConfiguration {
 
@@ -47,7 +51,6 @@ public class TestConfiguration {
     public TestConfiguration(List<Module> modules) {
         this.modules = modules;
     }
-    
     
     @Bean
     @ConditionalOnMissingBean
@@ -62,6 +65,7 @@ public class TestConfiguration {
     }
 
     @Bean
+    @ConditionalOnMissingBean
     public RestTemplateBuilder restTemplateBuilder(KeycloakTokenProducer keycloakTokenProducer) {
         ObjectMapper mapper = new ObjectMapper();
         mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES,
@@ -76,7 +80,7 @@ public class TestConfiguration {
         }
 
         MappingJackson2HttpMessageConverter jackson2HttpMessageConverter = new MappingJackson2HttpMessageConverter();
-        jackson2HttpMessageConverter.setSupportedMediaTypes(Collections.singletonList(MediaTypes.HAL_JSON));
+        jackson2HttpMessageConverter.setSupportedMediaTypes(Arrays.asList(MediaTypes.HAL_JSON, MediaType.APPLICATION_JSON));
         jackson2HttpMessageConverter.setObjectMapper(mapper);
 
         return new RestTemplateBuilder().additionalMessageConverters(

--- a/activiti-cloud-services-test/src/main/java/org/activiti/cloud/services/test/identity/keycloak/interceptor/KeycloakTokenProducer.java
+++ b/activiti-cloud-services-test/src/main/java/org/activiti/cloud/services/test/identity/keycloak/interceptor/KeycloakTokenProducer.java
@@ -30,7 +30,6 @@ import org.springframework.http.client.ClientHttpRequestInterceptor;
 import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.stereotype.Component;
 
-@Component
 public class KeycloakTokenProducer implements ClientHttpRequestInterceptor {
 
     private static final String AUTHORIZATION_HEADER = "Authorization";

--- a/activiti-cloud-services-test/src/main/java/org/activiti/cloud/starters/test/MyProducer.java
+++ b/activiti-cloud-services-test/src/main/java/org/activiti/cloud/starters/test/MyProducer.java
@@ -18,13 +18,9 @@ package org.activiti.cloud.starters.test;
 
 import org.activiti.cloud.api.model.shared.events.CloudRuntimeEvent;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.cloud.stream.annotation.EnableBinding;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.support.MessageBuilder;
-import org.springframework.stereotype.Component;
 
-@Component
-@EnableBinding(StreamProducer.class)
 public class MyProducer {
 
     private final MessageChannel producer;

--- a/activiti-cloud-services-test/src/main/resources/META-INF/spring.factories
+++ b/activiti-cloud-services-test/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+    org.activiti.cloud.services.test.TestConfiguration

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
   <properties>
     <activiti-cloud-build.version>7.1.10</activiti-cloud-build.version>
     <activiti-cloud-service-common.version>${project.version}</activiti-cloud-service-common.version>
-    <activiti-core-common.version>7.1.50</activiti-core-common.version>       
+    <activiti-core-common.version>7.1.52</activiti-core-common.version>       
     <activiti-cloud-api.version>7.1.46</activiti-cloud-api.version>
     <!-- dependencies -->
     <awaitility.version>3.0.0</awaitility.version>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <activiti-cloud-build.version>7.1.10</activiti-cloud-build.version>
     <activiti-cloud-service-common.version>${project.version}</activiti-cloud-service-common.version>
     <activiti-core-common.version>7.1.52</activiti-core-common.version>       
-    <activiti-cloud-api.version>7.1.46</activiti-cloud-api.version>
+    <activiti-cloud-api.version>7.1.47</activiti-cloud-api.version>
     <!-- dependencies -->
     <awaitility.version>3.0.0</awaitility.version>
     <commons-beanutils.version>1.9.3</commons-beanutils.version>


### PR DESCRIPTION
This PR fixes Spring Boot bean override problems by removing component scans from configuration classes and adds missing @ConditionalOnMissingBean annotation on beans created in Activiti Runtime Spring Boot Auto-configurations

Depends on https://github.com/Activiti/Activiti/pull/2904

Fixes https://github.com/Activiti/Activiti/issues/1399