### PR TITLE
[AAE-540] add support container starter based on Testcontainers

### DIFF
--- a/activiti-cloud-services-test/pom.xml
+++ b/activiti-cloud-services-test/pom.xml
@@ -82,7 +82,7 @@
     <dependency>
       <groupId>org.springframework.plugin</groupId>
       <artifactId>spring-plugin-core</artifactId>
-    </dependency>    
+    </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
@@ -124,5 +124,11 @@
       <groupId>net.javacrumbs.json-unit</groupId>
       <artifactId>json-unit-fluent</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>rabbitmq</artifactId>
+      <version>${testcontainers.version}</version>
+    </dependency>
+
   </dependencies>
 </project>

--- a/activiti-cloud-services-test/src/main/java/org/activiti/cloud/starters/test/SupportContainersInitializer.java
+++ b/activiti-cloud-services-test/src/main/java/org/activiti/cloud/starters/test/SupportContainersInitializer.java
@@ -1,0 +1,44 @@
+package org.activiti.cloud.starters.test;
+
+import org.springframework.boot.test.util.TestPropertyValues;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.RabbitMQContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.lifecycle.Startables;
+
+import java.util.stream.Stream;
+
+
+public class SupportContainersInitializer implements ApplicationContextInitializer<ConfigurableApplicationContext> {
+
+    private static GenericContainer keycloakContainer;
+
+    private static RabbitMQContainer rabbitMQContainer;
+
+
+    private static void startContainers() {
+        if (keycloakContainer == null && rabbitMQContainer == null) {
+            keycloakContainer = new GenericContainer("activiti/activiti-keycloak")
+                    .withExposedPorts(8180)
+                    .waitingFor(Wait.defaultWaitStrategy());
+
+
+            rabbitMQContainer = new RabbitMQContainer("rabbitmq:management");
+            Startables.deepStart(Stream.of(keycloakContainer, rabbitMQContainer)).join();
+        }
+    }
+
+    public void initialize(ConfigurableApplicationContext configurableApplicationContext) {
+
+        startContainers();
+
+        TestPropertyValues.of(
+                "keycloak.auth-server-url=http://" + keycloakContainer.getContainerIpAddress() + ":" + keycloakContainer.getFirstMappedPort() + "/auth",
+                "spring.rabbitmq.host=" + rabbitMQContainer.getContainerIpAddress(),
+                "spring.rabbitmq.port=" + rabbitMQContainer.getAmqpPort()
+        ).applyTo(configurableApplicationContext.getEnvironment());
+    }
+}
+

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
   <properties>
     <activiti-cloud-build.version>7.1.10</activiti-cloud-build.version>
     <activiti-cloud-service-common.version>${project.version}</activiti-cloud-service-common.version>
-    <activiti-core-common.version>7.1.52</activiti-core-common.version>       
+    <activiti-core-common.version>7.1.52</activiti-core-common.version>
     <activiti-cloud-api.version>7.1.47</activiti-cloud-api.version>
     <!-- dependencies -->
     <awaitility.version>3.0.0</awaitility.version>
@@ -39,6 +39,7 @@
     <asciidoctor.version>1.5.6</asciidoctor.version>
     <json-unit.version>1.24.0</json-unit.version>
     <javax.annotation.version>1.3.2</javax.annotation.version>
+    <testcontainers.version>1.12.2</testcontainers.version>
   </properties>
 
   <modules>


### PR DESCRIPTION
Add a Spring ApplicationContextInitializer to be used in integration tests to start rabbitmwq and keycloak support containers