### PR TITLE
Auto configure test producer after BindingServiceConfiguration

### DIFF
--- a/activiti-cloud-services-test/src/main/java/org/activiti/cloud/services/test/TestConfiguration.java
+++ b/activiti-cloud-services-test/src/main/java/org/activiti/cloud/services/test/TestConfiguration.java
@@ -20,17 +20,15 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.Module;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.activiti.cloud.services.identity.keycloak.KeycloakProperties;
 import org.activiti.cloud.services.test.identity.keycloak.interceptor.KeycloakTokenProducer;
-import org.activiti.cloud.starters.test.MyProducer;
-import org.activiti.cloud.starters.test.StreamProducer;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.web.client.RestTemplateAutoConfiguration;
 import org.springframework.boot.web.client.RestTemplateBuilder;
-import org.springframework.cloud.stream.annotation.EnableBinding;
-import org.springframework.cloud.stream.binding.BindingService;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.hateoas.MediaTypes;
@@ -38,14 +36,9 @@ import org.springframework.hateoas.hal.Jackson2HalModule;
 import org.springframework.http.MediaType;
 import org.springframework.http.converter.StringHttpMessageConverter;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
-import org.springframework.messaging.MessageChannel;
-
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.Module;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 @Configuration
-@AutoConfigureBefore(value=RestTemplateAutoConfiguration.class)
+@AutoConfigureBefore(value = RestTemplateAutoConfiguration.class)
 public class TestConfiguration {
 
     private final List<Module> modules;
@@ -54,17 +47,6 @@ public class TestConfiguration {
         this.modules = modules;
     }
 
-    @ConditionalOnBean(BindingService.class)
-    @EnableBinding(StreamProducer.class)
-    static class MyProducerConfiguration {
-    
-        @Bean
-        @ConditionalOnMissingBean
-        public MyProducer myProducer(MessageChannel producer) {
-            return new MyProducer(producer);
-        }
-    }
-    
     @Bean
     @ConditionalOnMissingBean
     public KeycloakTokenProducer keycloakTokenProducer(KeycloakProperties keycloakProperties) {

--- a/activiti-cloud-services-test/src/main/java/org/activiti/cloud/services/test/TestProducerAutoConfiguration.java
+++ b/activiti-cloud-services-test/src/main/java/org/activiti/cloud/services/test/TestProducerAutoConfiguration.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2019 Alfresco, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.cloud.services.test;
+
+import org.activiti.cloud.starters.test.MyProducer;
+import org.activiti.cloud.starters.test.StreamProducer;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.cloud.stream.annotation.EnableBinding;
+import org.springframework.cloud.stream.binding.BindingService;
+import org.springframework.cloud.stream.config.BindingServiceConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.MessageChannel;
+
+@Configuration
+@AutoConfigureAfter(value = BindingServiceConfiguration.class)
+public class TestProducerAutoConfiguration {
+
+    @ConditionalOnBean(BindingService.class)
+    @EnableBinding(StreamProducer.class)
+    static class MyProducerConfiguration {
+    
+        @Bean
+        @ConditionalOnMissingBean
+        public MyProducer myProducer(MessageChannel producer) {
+            return new MyProducer(producer);
+        }
+    }
+    
+}

--- a/activiti-cloud-services-test/src/main/resources/META-INF/spring.factories
+++ b/activiti-cloud-services-test/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,3 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-    org.activiti.cloud.services.test.TestConfiguration
+    org.activiti.cloud.services.test.TestConfiguration,\
+  org.activiti.cloud.services.test.TestProducerAutoConfiguration


### PR DESCRIPTION
The propagation PR on query service was failing because BindingServiceConfiguration (that creates BindingService bean) was running after TestConfiguration
https://github.com/Activiti/activiti-cloud-query-service/pull/372

Related to https://github.com/Activiti/activiti-cloud-service-common/pull/239