### PR TITLE
fix(AAE-1187): Added `spring-messaging` dependency to resolve Jbehave error in Acceptance Tests

### DIFF
--- a/activiti-cloud-services-test/pom.xml
+++ b/activiti-cloud-services-test/pom.xml
@@ -60,6 +60,10 @@
       <artifactId>activiti-cloud-services-commons-io</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-messaging</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-test</artifactId>
     </dependency>


### PR DESCRIPTION
After fixing https://github.com/Activiti/activiti-cloud-service-common/pull/241 the Jbehave is breaking on MyProducer interface scan with MessageChannel import.  MessageChannel is now missing on classpath in modelling-acceptance-tests , so it blows up with ClassDefinitionNotFound error in JVM. 

We need to have `spring-messaging` dependency in `activiti-cloud-services-test` to avoid this.