### PR TITLE
fix: Revert changes for activiti-build parent and activiti-core-dependencies propagation

### DIFF
--- a/activiti-cloud-service-common-dependencies/pom.xml
+++ b/activiti-cloud-service-common-dependencies/pom.xml
@@ -13,20 +13,6 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>org.activiti.cloud.api</groupId>
-        <artifactId>activiti-cloud-api-dependencies</artifactId>
-        <version>${activiti-cloud-api.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.activiti.core.common</groupId>
-        <artifactId>activiti-core-common-dependencies</artifactId>
-        <version>${activiti-core-common.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
         <groupId>org.activiti.cloud.common</groupId>
         <artifactId>activiti-cloud-service-common-config</artifactId>
         <version>${activiti-cloud-service-common.version}</version>

--- a/activiti-cloud-service-common-dependencies/pom.xml
+++ b/activiti-cloud-service-common-dependencies/pom.xml
@@ -13,13 +13,6 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>org.activiti</groupId>
-        <artifactId>activiti-core-dependencies</artifactId>
-        <version>${activiti-core.version}</version>
-        <scope>import</scope>
-        <type>pom</type>
-      </dependency>
-      <dependency>
         <groupId>org.activiti.cloud.api</groupId>
         <artifactId>activiti-cloud-api-dependencies</artifactId>
         <version>${activiti-cloud-api.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,20 @@
         <type>pom</type>
       </dependency>
       <dependency>
+        <groupId>org.activiti.cloud.api</groupId>
+        <artifactId>activiti-cloud-api-dependencies</artifactId>
+        <version>${activiti-cloud-api.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.activiti.core.common</groupId>
+        <artifactId>activiti-core-common-dependencies</artifactId>
+        <version>${activiti-core-common.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
         <groupId>org.keycloak.bom</groupId>
         <artifactId>keycloak-adapter-bom</artifactId>
         <version>${keycloak-spring-boot.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -35,8 +35,6 @@
   </modules>
   <properties>
     <project.scm.repository>activiti-cloud-service-common</project.scm.repository>
-    <activiti-api.version>7.1.173</activiti-api.version>
-    <activiti-core.version>7.1.181</activiti-core.version>
     <activiti-cloud-build.version>7.1.30</activiti-cloud-build.version>
     <activiti-cloud-service-common.version>${project.version}</activiti-cloud-service-common.version>
     <activiti-core-common.version>7.1.181</activiti-core-common.version>


### PR DESCRIPTION
This PR reverts changes for activiti-build parent and activiti-core-dependencies propagation

Part of https://github.com/Activiti/Activiti/issues/3099